### PR TITLE
Fix pathogen warning from runtime_append_all_bundles deprecation

### DIFF
--- a/ohmyvim/scripts.py
+++ b/ohmyvim/scripts.py
@@ -305,7 +305,7 @@ class Manager(object):
             fd.write('source %s\n' % join(self.ohmyvim, 'env.vim'))
             fd.write('source %s\n' % join(self.runtime, 'vim-pathogen',
                                                'autoload', 'pathogen.vim'))
-            fd.write('call pathogen#runtime_append_all_bundles()\n')
+            fd.write('call pathogen#incubate()\n')
             fd.write('source %s\n' % join(self.ohmyvim, 'theme.vim'))
             fd.write('source %s\n' % join(self.runtime, 'oh-my-vim',
                                           'plugin', 'ohmyvim.vim'))

--- a/plugin/ohmyvim.vim
+++ b/plugin/ohmyvim.vim
@@ -14,7 +14,7 @@ function! OhMyVim(args)
         echo 'OhMyVim v'.split(system(g:ohmyvim.' version'), '\n')[0]
     elseif a:splitted[0] == 'theme' && len(a:splitted) > 1
         call system(g:ohmyvim.' '.a:args)
-        call pathogen#runtime_append_all_bundles()
+        call pathogen#incubate()
         source ~/.vim/ohmyvim/theme.vim
     else
         echo system(g:ohmyvim.' '.a:args)


### PR DESCRIPTION
Removes a warning that came along with [this](https://github.com/maksimr/vim-pathogen/commit/df8f1b0b309adb97923731ba821a2f176edf20f0) change to pathogen.
