### PR TITLE
add PinyinSearch to config.ini

### DIFF
--- a/ohmyvim/config.ini
+++ b/ohmyvim/config.ini
@@ -3800,4 +3800,4 @@ pathogen.vim = https://github.com/vim-scripts/pathogen.vim.git
 matlab_run.vim = https://github.com/vim-scripts/matlab_run.vim.git
 phps = https://github.com/vim-scripts/phps.git
 jedi-vim = https://github.com/davidhalter/jedi-vim.git
-
+PinyinSearch = https://github.com/ppwwyyxx/vim-PinyinSearch.git


### PR DESCRIPTION
PinyinSearch is a vim plugin that help Chinese users to seach Chinese in vim by its pronunciation, instead of typing the Chinese.
