### PR TITLE
update "jedi-vim" post instal script

### DIFF
--- a/tools/post_install/jedi-vim.sh
+++ b/tools/post_install/jedi-vim.sh
@@ -2,5 +2,5 @@
 # fetch submodules
 
 cd $HOME/.vim/bundle/jedi-vim
-git submodule init
-git submodule update
+git --git-dir=.git submodule init
+git --git-dir=.git submodule update


### PR DESCRIPTION
Somehow git do not understand that "jedi-vim" is a repo.
We have to point "git dir" for correct work
