### PR TITLE
Changed pathogen#runtime_append_all_bundles to pathogen#incubate

### DIFF
--- a/ohmyvim/scripts.py
+++ b/ohmyvim/scripts.py
@@ -305,7 +305,7 @@ class Manager(object):
             fd.write('source %s\n' % join(self.ohmyvim, 'env.vim'))
             fd.write('source %s\n' % join(self.runtime, 'vim-pathogen',
                                                'autoload', 'pathogen.vim'))
-            fd.write('call pathogen#runtime_append_all_bundles()\n')
+            fd.write('call pathogen#incubate()\n')
             fd.write('source %s\n' % join(self.ohmyvim, 'theme.vim'))
             fd.write('source %s\n' % join(self.runtime, 'oh-my-vim',
                                           'plugin', 'ohmyvim.vim'))


### PR DESCRIPTION
I changed this because of deprecation warnung on Debian Wheezy x64 with python2.7. The deprecation warning had to be skipped by pressing Enter, so I fixed it.
I haven't tested it on other systems but I think it's just related to pathogen. 
